### PR TITLE
4.1 Updates

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,6 @@
 
 default['zeromq']['dir'] = '/usr/local'
 default['zeromq']['install_method'] = 'source'
-default['zeromq']['sha256_sum'] = '09653e56a466683edb2f87ee025c4de55b8740df69481b9d7da98748f0c92124'
-default['zeromq']['src_url'] = 'http://download.zeromq.org'
-default['zeromq']['version'] = '3.2.5'
+default['zeromq']['src_url'] = 'https://github.com/zeromq/zeromq4-1.git'
+default['zeromq']['version'] = 'v4.1.4'
 default['zeromq']['creates'] = 'libzmq.so'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email 'plu@pqpq.de'
 license          'Apache 2.0'
 description      'Installs/Configures zeromq'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.6'
+version          '1.1.0'
 name             'zeromq'
 provides         'zeromq'
 
@@ -18,3 +18,4 @@ end
 %w(debian ubuntu centos redhat).each do |os|
   supports os
 end
+

--- a/recipes/install_from_source.rb
+++ b/recipes/install_from_source.rb
@@ -56,5 +56,5 @@ end
 execute 'ldconfig' do
   action :nothing
   command 'ldconfig'
-  subscribes :create, 'template[/etc/ld.so.conf.d/zeromq.conf]', :immediately
+  subscribes :run, 'template[/etc/ld.so.conf.d/zeromq.conf]', :immediately
 end


### PR DESCRIPTION
default version updated to latest 4.1.4 release
Now pulls directly from git rather than from a 'release' snapshot tarball
Version can now target 'current' master, or any branches or tags (such as the v4.1.4 tag).
moved source to github.com (larger organization, via https)
minor version bump
added use of 'autogen.sh' in build script as configure is no longer part of the base and must be generated
